### PR TITLE
feat: enhance contributor views and statistics

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,8 +31,8 @@
             <div class="container">
                 <button class="tab-btn active" data-tab="active">Active Contributors</button>
                 <button class="tab-btn" data-tab="daily">Daily View</button>
-                <button class="tab-btn" data-tab="archive">Archive</button>
                 <button class="tab-btn" data-tab="statistics">Statistics</button>
+                <button class="tab-btn" data-tab="archive">Archive</button>
             </div>
         </nav>
 
@@ -176,12 +176,10 @@
                                 <thead>
                                     <tr>
                                         <th><input type="checkbox" id="selectAll"></th>
-                                        <th>Email</th>
-                                        <th>Assignment</th>
-                                        <th>Result</th>
-                                        <th>Date Added</th>
-                                        <th>Date Assigned</th>
-                                        <th>Date Completed</th>
+                                        <th class="sortable" data-sort="email">Email</th>
+                                        <th class="sortable" data-sort="status">Assignment</th>
+                                        <th class="sortable" data-sort="result">Result</th>
+                                        <th class="sortable" data-sort="dateAdded">Date Added</th>
                                         <th>Actions</th>
                                     </tr>
                                 </thead>
@@ -231,47 +229,10 @@
                                         <th>Assignment</th>
                                         <th>Result</th>
                                         <th>Date Added</th>
-                                        <th>Date Assigned</th>
-                                        <th>Date Completed</th>
                                         <th>Actions</th>
                                     </tr>
                                 </thead>
                                 <tbody id="dailyTableBody">
-                                    <!-- Table rows will be populated by JavaScript -->
-                                </tbody>
-                            </table>
-                        </div>
-                    </div>
-                </div>
-
-                <!-- Archive Tab -->
-                <div id="archive-tab" class="tab-content">
-                    <div class="section">
-                        <div class="section-header">
-                            <h2>Archived Contributors</h2>
-                            <div class="section-actions">
-                                <input type="text" id="archiveSearchInput" class="form-control search-input" placeholder="Search archived contributors...">
-                                <select id="archiveStatusFilter" class="form-control">
-                                    <option value="">All Statuses</option>
-                                    <option value="passed">Passed</option>
-                                    <option value="failed">Failed</option>
-                                </select>
-                            </div>
-                        </div>
-                        
-                        <div class="table-container">
-                            <table class="contributors-table">
-                                <thead>
-                                    <tr>
-                                        <th>Email</th>
-                                        <th>Result</th>
-                                        <th>Date Added</th>
-                                        <th>Date Completed</th>
-                                        <th>Date Archived</th>
-                                        <th>Actions</th>
-                                    </tr>
-                                </thead>
-                                <tbody id="archiveTableBody">
                                     <!-- Table rows will be populated by JavaScript -->
                                 </tbody>
                             </table>
@@ -319,6 +280,41 @@
                                     <canvas id="weeklySummaryChart"></canvas>
                                 </div>
                             </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Archive Tab -->
+                <div id="archive-tab" class="tab-content">
+                    <div class="section">
+                        <div class="section-header">
+                            <h2>Archived Contributors</h2>
+                            <div class="section-actions">
+                                <input type="text" id="archiveSearchInput" class="form-control search-input" placeholder="Search archived contributors...">
+                                <select id="archiveStatusFilter" class="form-control">
+                                    <option value="">All Statuses</option>
+                                    <option value="passed">Passed</option>
+                                    <option value="failed">Failed</option>
+                                </select>
+                            </div>
+                        </div>
+
+                        <div class="table-container">
+                            <table class="contributors-table">
+                                <thead>
+                                    <tr>
+                                        <th>Email</th>
+                                        <th>Result</th>
+                                        <th>Date Added</th>
+                                        <th>Date Completed</th>
+                                        <th>Date Archived</th>
+                                        <th>Actions</th>
+                                    </tr>
+                                </thead>
+                                <tbody id="archiveTableBody">
+                                    <!-- Table rows will be populated by JavaScript -->
+                                </tbody>
+                            </table>
                         </div>
                     </div>
                 </div>

--- a/style.css
+++ b/style.css
@@ -1104,6 +1104,10 @@ select.form-control {
   letter-spacing: 0.025em;
 }
 
+.contributors-table th.sortable {
+  cursor: pointer;
+}
+
 .contributors-table tbody tr:hover {
   background-color: var(--color-bg-2);
 }
@@ -1126,9 +1130,9 @@ select.form-control {
 }
 
 .status-badge--assigned {
-  background-color: var(--color-bg-6);
-  color: var(--color-warning);
-  border: 1px solid rgba(var(--color-warning-rgb), 0.2);
+  background-color: var(--color-gray-200);
+  color: var(--color-gray-400);
+  border: 1px solid var(--color-gray-300);
 }
 
 .status-badge--passed {


### PR DESCRIPTION
## Summary
- enable sorting on key columns in Active Contributors and streamline table layout
- show cumulative Daily View summary and simplify columns
- refine statistics with percentage pass/fail rates, proper assigned colors, and weekly status breakdown

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68baede7d4248332bf3cff2b600f502f