### PR TITLE
Add summary view and improve status handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
         <nav class="nav-tabs">
             <div class="container">
                 <button class="tab-btn active" data-tab="active">Active Contributors</button>
-                <button class="tab-btn" data-tab="daily">Daily View</button>
+                <button class="tab-btn" data-tab="summary">Summary</button>
                 <button class="tab-btn" data-tab="statistics">Statistics</button>
                 <button class="tab-btn" data-tab="archive">Archive</button>
             </div>
@@ -191,32 +191,26 @@
                     </div>
                 </div>
 
-                <!-- Daily View Tab -->
-                <div id="daily-tab" class="tab-content">
+                <!-- Summary Tab -->
+                <div id="summary-tab" class="tab-content">
                     <div class="section">
-                        <h2>Daily View</h2>
-                        <div class="daily-controls">
-                            <div class="form-group">
-                                <label class="form-label" for="dailyDatePicker">Select Date</label>
-                                <input type="date" id="dailyDatePicker" class="form-control">
-                            </div>
-                        </div>
-                        
-                        <div class="daily-stats">
+                        <h2>Summary</h2>
+
+                        <div class="summary-stats">
                             <div class="stat-card">
-                                <div class="stat-value" id="dailyTotalAdded">0</div>
+                                <div class="stat-value" id="summaryTotalAdded">0</div>
                                 <div class="stat-label">Total Added</div>
                             </div>
                             <div class="stat-card">
-                                <div class="stat-value" id="dailyAssigned">0</div>
+                                <div class="stat-value" id="summaryAssigned">0</div>
                                 <div class="stat-label">Assigned</div>
                             </div>
                             <div class="stat-card">
-                                <div class="stat-value" id="dailyPassed">0</div>
+                                <div class="stat-value" id="summaryPassed">0</div>
                                 <div class="stat-label">Passed</div>
                             </div>
                             <div class="stat-card">
-                                <div class="stat-value" id="dailyFailed">0</div>
+                                <div class="stat-value" id="summaryFailed">0</div>
                                 <div class="stat-label">Failed</div>
                             </div>
                         </div>
@@ -229,10 +223,9 @@
                                         <th>Assignment</th>
                                         <th>Result</th>
                                         <th>Date Added</th>
-                                        <th>Actions</th>
                                     </tr>
                                 </thead>
-                                <tbody id="dailyTableBody">
+                                <tbody id="summaryTableBody">
                                     <!-- Table rows will be populated by JavaScript -->
                                 </tbody>
                             </table>

--- a/style.css
+++ b/style.css
@@ -1106,6 +1106,24 @@ select.form-control {
 
 .contributors-table th.sortable {
   cursor: pointer;
+  position: relative;
+}
+
+.contributors-table th.sortable::after {
+  content: '\2195';
+  margin-left: var(--space-4);
+  font-size: 0.8em;
+  color: var(--color-gray-400);
+}
+
+.contributors-table th.sorted-asc::after {
+  content: '\2191';
+  color: var(--color-primary);
+}
+
+.contributors-table th.sorted-desc::after {
+  content: '\2193';
+  color: var(--color-primary);
 }
 
 .contributors-table tbody tr:hover {
@@ -1156,6 +1174,30 @@ select.form-control {
   color: var(--color-text);
 }
 
+.status-select--pending {
+  background-color: var(--color-bg-1);
+  color: var(--color-primary);
+  border: 1px solid rgba(var(--color-teal-500-rgb), 0.2);
+}
+
+.status-select--assigned {
+  background-color: var(--color-gray-200);
+  color: var(--color-gray-400);
+  border: 1px solid var(--color-gray-300);
+}
+
+.status-select--passed {
+  background-color: var(--color-bg-3);
+  color: var(--color-success);
+  border: 1px solid rgba(var(--color-success-rgb), 0.2);
+}
+
+.status-select--failed {
+  background-color: var(--color-bg-4);
+  color: var(--color-error);
+  border: 1px solid rgba(var(--color-error-rgb), 0.2);
+}
+
 .action-btn {
   padding: var(--space-4) var(--space-8);
   margin: 0 var(--space-2);
@@ -1190,15 +1232,7 @@ select.form-control {
   background-color: rgba(var(--color-teal-500-rgb), 0.1);
 }
 
-.daily-controls {
-  background-color: var(--color-surface);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-lg);
-  padding: var(--space-20);
-  margin-bottom: var(--space-24);
-}
-
-.daily-stats {
+.summary-stats {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
   gap: var(--space-16);
@@ -1401,7 +1435,7 @@ select.form-control {
     grid-template-columns: 1fr;
   }
 
-  .daily-stats {
+  .summary-stats {
     grid-template-columns: repeat(2, 1fr);
   }
 
@@ -1426,7 +1460,7 @@ select.form-control {
 }
 
 @media (max-width: 480px) {
-  .daily-stats {
+  .summary-stats {
     grid-template-columns: 1fr;
   }
 


### PR DESCRIPTION
## Summary
- rename Daily View to Summary and show cumulative stats
- add column sorting indicators and colored status selectors on Active Contributors
- fix status distribution chart to count all assigned contributors

## Testing
- `node --check app.js`
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68baf16eadfc8332b6359a2c91a79569